### PR TITLE
dereference libraries while deploying

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -87,6 +87,6 @@ for i in "$SOURCE/lib/"*; do
 		$i/deploy.sh "$TARGET/lib/$o"
 	else
 		echo "Copying $o"
-		cp -r "$i" "$TARGET/lib"
+		cp -rL "$i" "$TARGET/lib"
 	fi
 done


### PR DESCRIPTION
libs might be soft linked; this copies the target folder instead of the symbolic link.
Enyo-DCO-1.1-Signed-off-by: Johann Jacobsohn johann.jacobsohn@directbox.com
