### PR TITLE
ENYO-2125: allow forking the GitHub project from any URL-scheme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "enyo"]
 	path = enyo
-	url = https://github.com/enyojs/enyo.git
+	url = ../../enyojs/enyo.git
 [submodule "lib/onyx"]
 	path = lib/onyx
-	url = https://github.com/enyojs/onyx.git
+	url = ../../enyojs/onyx.git
 [submodule "lib/layout"]
 	path = lib/layout
-	url = https://github.com/enyojs/layout.git
+	url = ../../enyojs/layout.git


### PR DESCRIPTION
Use relative URL's all-the-way up to the GitHub root.  Benefits:
- Keep the ability to clone using both `ssh` and `https` URLs (for
  external developers or the fortunate ones that are working behind
  a transparent http proxy)
- Allow forking the project, because later `clone` operation does not
  require to have forked every submodule.

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
