### PR TITLE
Add charset attributes to script tags to support use in IE where scripts...

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -11,9 +11,9 @@
 		<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
 		<!-- <script src="enyo/tools/minifier/node_modules/less/dist/less-1.3.3.min.js"></script> -->
 		<!-- enyo (debug) -->
-		<script src="enyo/enyo.js"></script>
+		<script src="enyo/enyo.js" charset="utf-8"></script>
 		<!-- application (debug) -->
-		<script src="source/package.js" type="text/javascript"></script>
+		<script src="source/package.js" charset="utf-8"></script>
 	</head>
 	<body class="enyo-unselectable">
 		<script>

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
 		<link href="build/enyo.css" rel="stylesheet"/>
 		<link href="build/app.css" rel="stylesheet"/>
 		<!-- js -->
-		<script src="build/enyo.js"></script>
-		<script src="build/app.js"></script>
+		<script src="build/enyo.js" charset="utf-8"></script>
+		<script src="build/app.js" charset="utf-8"></script>
 	</head>
 	<body class="enyo-unselectable">
 		<script>


### PR DESCRIPTION
... might not be interpreted correctly if they have non-ASCII characters.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
