### PR TITLE
Enhancement: add support for Firefox OS on deploy tools

### DIFF
--- a/tools/deploy.bat
+++ b/tools/deploy.bat
@@ -35,6 +35,12 @@ if not "%1" == "" (
 	palm-package.bat %DEST% --outdir=%SRC%\bin
     )
 
+    if "%1" == "--firefoxos" (
+  REM copy manifest.webapp files
+  for %%A in ("%~dp0./..") do SET DEST=%TOOLS%..\deploy\%%~nA
+  copy %SRC%\manifest.webapp %DEST%
+    )
+
     shift
     goto again
 )

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -28,13 +28,21 @@ while [ "$1" != "" ]; do
 		-w | --cordova-webos )
 			# copy appinfo.json and cordova*.js files
 			DEST="$TOOLS/../deploy/"${PWD##*/}
-			
-			cp "$SRC"/appinfo.json "$DEST" -v
-			cp "$SRC"/cordova*.js "$DEST" -v
-			
+
+			cp -v "$SRC"/appinfo.json "$DEST"
+			cp -v "$SRC"/cordova*.js "$DEST"
+
 			# package it up
 			mkdir -p "$DEST/bin"
 			palm-package "$DEST/bin"
+			;;
+	esac
+	case $1 in
+		-fxos | --firefoxos )
+			# copy manifest.webapp files
+			DEST="$TOOLS/../deploy/"${PWD##*/}
+
+			cp -v "$SRC"/manifest.webapp "$DEST"
 			;;
 	esac
 	shift


### PR DESCRIPTION
This pull request includes two things:

First: the "-v" parameter in deploy.sh in Cordova webOS case is in the wrong position and this affects Mac OS X

Second: I added support for bundling Firefox OS application manifest if you pass the -fxos or --firefoxos parameter. The file called manifest.webapp is used by Firefox OS much like appinfo.json is used by webOS.

Enyo-DCO-1.1-Signed-off-by: Andre Alves Garzia andre@andregarzia.com
