### PR TITLE
added .bowerrc file. Enables adding libraries to the  folder with bower.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "lib"
+}


### PR DESCRIPTION
Many web developers rely on [Bower](http://bower.io) to manage their dependencies. 

This pull request add a **.bowerrc** file to the bootplate. This file is used to configure bower. In it we set the folder used as a target when installing libraries. Meaning that any library installed with Bower will go to $lib.

Since Bower can work with Github Repos, this addition allow you do do stuff such as:

```bash
$ bower install webOS-ports/webos-lib
```
To install the **webOS Lib** from **webOS Ports project**. Any combination of ```user/repo``` can be used. This is a great way to add components from the community gallery to your project.

Enyo-DCO-1.1-Signed-off-by: Andre Alves Garzia <andre@andregarzia.com>